### PR TITLE
Add automatic deletion of floating tasks 24 hours after completion

### DIFF
--- a/txtodo/AddItem.swift
+++ b/txtodo/AddItem.swift
@@ -95,6 +95,8 @@ struct addMainTask: View {
                             newFloatingTask.priority = Int16(self.newTaskPriority)
                             newFloatingTask.notes = [String]()
                             newFloatingTask.id = UUID()
+                            newFloatingTask.completionDate = Date.init()
+                            newFloatingTask.markedForDeletion = false
                         }
                         do {
                             try self.managedObjectContext.save()

--- a/txtodo/Data Models/FloatingTask+CoreDataProperties.swift
+++ b/txtodo/Data Models/FloatingTask+CoreDataProperties.swift
@@ -22,5 +22,7 @@ extension FloatingTask {
     @NSManaged public var name: String
     @NSManaged public var notes: Array<String>
     @NSManaged public var id: UUID
+    @NSManaged public var completionDate: Date
+    @NSManaged public var markedForDeletion: Bool
 
 }

--- a/txtodo/Data Models/txtodo.xcdatamodeld/txtodo.xcdatamodel/contents
+++ b/txtodo/Data Models/txtodo.xcdatamodeld/txtodo.xcdatamodel/contents
@@ -10,13 +10,15 @@
     </entity>
     <entity name="FloatingTask" representedClassName="FloatingTask" syncable="YES">
         <attribute name="completed" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="completionDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="markedForDeletion" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="notes" optional="YES" attributeType="Transformable"/>
         <attribute name="priority" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
     <elements>
         <element name="DailyTask" positionX="-63" positionY="-18" width="128" height="133"/>
-        <element name="FloatingTask" positionX="-63" positionY="27" width="128" height="118"/>
+        <element name="FloatingTask" positionX="-63" positionY="27" width="128" height="148"/>
     </elements>
 </model>

--- a/txtodo/HomeScreen.swift
+++ b/txtodo/HomeScreen.swift
@@ -46,6 +46,14 @@ struct HomeScreen: View {
                             priority: Int(task.priority)
                         )
                             .environment(\.managedObjectContext, self.managedObjectContext)
+                            .onAppear(perform: {
+                                if task.markedForDeletion && !(Calendar.current.component(.day, from: task.completionDate) == self.currentDay) {
+                                    self.managedObjectContext.performAndWait {
+                                        self.managedObjectContext.delete(task)
+                                        try? self.managedObjectContext.save()
+                                    }
+                                }
+                            })
                     }
                     if self.dailyTasks.count > 0 {
                         SectionLabel(text: "daily")

--- a/txtodo/TaskView.swift
+++ b/txtodo/TaskView.swift
@@ -26,6 +26,12 @@ struct floatingTaskView: View {
                     self.completed.toggle()
                     self.managedObjectContext.performAndWait {
                         self.task.completed = self.completed
+                        if self.completed {
+                            self.task.completionDate = Date.init()
+                            self.task.markedForDeletion = true
+                        } else {
+                            self.task.markedForDeletion = false
+                        }
                         try? self.managedObjectContext.save()
                     }
                 }) {


### PR DESCRIPTION
Previously, you had to manually delete a floating task. This was inconvenient, because even tasks you had marked as completed had to be manually deleted. This way, you no longer have to choose to delete completed tasks, as they will be removed for you at midnight.